### PR TITLE
`popwin:display-buffer' doesn't work at all with Emacs 23.1

### DIFF
--- a/popwin.el
+++ b/popwin.el
@@ -96,7 +96,9 @@ minibuffer window is selected."
 
 (defun popwin:called-interactively-p ()
   (with-no-warnings
-    (if (>= emacs-major-version 23)
+    (if (or (>= emacs-major-version 24)
+            (and (= emacs-major-version 23)
+                 (>= emacs-minor-version 2)))
         (called-interactively-p 'any)
       (called-interactively-p))))
 


### PR DESCRIPTION
```
popwin:called-interactively-p: Wrong number of arguments: called-interactively-p, 1
```

The one-argument form of `called-interactively-p` has been supported since Emacs 23.**2**. `popwin:called-interactively-p` needs to check the minor version number as well.
