### PR TITLE
ミニバッファを noselect  させないようにする

### DIFF
--- a/popwin.el
+++ b/popwin.el
@@ -573,7 +573,7 @@ specifies default values of the selected config."
                                    :width win-width
                                    :height win-height
                                    :position win-position
-                                   :noselect (or (minibufferp) win-noselect)
+                                   :noselect win-noselect
                                    :stick win-stick))
           (funcall if-config-not-found buffer))))
 


### PR DESCRIPTION
該当箇所で(minibufferp) を評価すると，ミニバッファで入力を求める場合に常に noselect となり，ユーザがカーソルを移動しなければならない．ただし，アルゴリズム全体を検査していないため，このパッチが最良の解決方法である保証はない．一方，anything-grep-by-name を実行すると逆の挙動になる．更なる検証が必要．
