### PR TITLE
Bug fix for batch test execution.

### DIFF
--- a/test/popwin-test.el
+++ b/test/popwin-test.el
@@ -13,6 +13,7 @@
   (declare (indent 0) (debug t))
   `(save-excursion
     (save-window-excursion
+      (popwin:close-popup-window)
       (delete-other-windows)
       (let ((buf1 (get-buffer-create "*buf1*"))
             (buf2 (get-buffer-create "*buf2*"))


### PR DESCRIPTION
Add clean up before test.

失敗したテストのゴミ(window)が残っていたため、後続のテストも失敗していました。
テスト前にもwindowをcleanupするようにしました。

これで私の環境ではテストの失敗数が７個->２個になりました。
