### PR TITLE
Added workaround for #62.

### DIFF
--- a/popwin.el
+++ b/popwin.el
@@ -135,8 +135,7 @@ minibuffer window is selected."
 
 (defun popwin:set-window-point (window point)
   "Forcely set window-point."
-  (with-current-buffer (popwin:dummy-buffer)
-    (set-window-point window point)))
+    (set-window-point window point))
 
 (defun popwin:window-trailing-edge-adjustable-p (window)
   "Return t if a trailing edge of WINDOW is adjustable."


### PR DESCRIPTION
とりあえずの回避策は見つけて、今あるテストは成功することを確認しました。
ですが、対象のpopwin:set-window-pointの e3f2a0e の変更が何かしらの不具合修正の気がします。
変更理由とそのときの不具合の内容は思い出せますでしょうか？
