### PR TITLE
Mark "*Miniedit Help*" as :noselect.

### DIFF
--- a/popwin.el
+++ b/popwin.el
@@ -681,6 +681,7 @@ be closed by `popwin:close-popup-window'."
 
 (defcustom popwin:special-display-config
   '(;; Emacs
+    ("*Miniedit Help*" :noselect t)
     help-mode
     (completion-list-mode :noselect t)
     (compilation-mode :noselect t)


### PR DESCRIPTION
Miniedit automatically opens and closes its help buffer, which is not meant to be selected upon creation.

cf. http://www.emacswiki.org/emacs/MiniEdit
